### PR TITLE
Add copy / paste / cut / undo / redo / selectAll keyboard shortcuts

### DIFF
--- a/src/controller/menu-controller.js
+++ b/src/controller/menu-controller.js
@@ -1,0 +1,29 @@
+const { Menu } = require('electron')
+const macOS = process.platform === 'darwin' ? true : false
+
+class MenuController {
+    constructor() {
+        this.init()
+    }
+
+    init() {
+        const appMenuTemplate = [{
+            label: "Edit",
+            submenu: [
+                { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
+                { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
+                { type: "separator" },
+                { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
+                { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
+                { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
+                { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" }
+            ]}
+        ];
+
+        if(macOS){
+            Menu.setApplicationMenu(Menu.buildFromTemplate(appMenuTemplate));
+        }
+    }
+}
+
+module.exports = MenuController

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const { app, Menu } = require('electron')
+const { app } = require('electron')
 const MailWindowController = require('./controller/mail-window-controller')
 const TrayController = require('./controller/tray-controller')
 
@@ -49,27 +49,6 @@ class ElectronOutlook {
         this.mailController.show()
       }
     })
-    
-    const menuTemplate = [{
-      label: "Application",
-      submenu: [
-        { label: "About Application", selector: "orderFrontStandardAboutPanel:" },
-        { type: "separator" },
-        { label: "Quit", accelerator: "Command+Q", click: function() { app.quit(); }}
-      ]}, {
-      label: "Edit",
-      submenu: [
-        { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
-        { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
-        { type: "separator" },
-        { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
-        { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
-        { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
-        { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" }
-      ]}
-    ];
-
-    Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
   }
 
   createControllers() {

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,13 @@
 const { app } = require('electron')
 const MailWindowController = require('./controller/mail-window-controller')
 const TrayController = require('./controller/tray-controller')
+const MenuController = require('./controller/menu-controller')
 
 class ElectronOutlook {
   constructor() {
     this.mailController = null;
     this.trayController = null;
+    this.menuController = null
   }
 
   // init method, the entry point of the app
@@ -54,6 +56,7 @@ class ElectronOutlook {
   createControllers() {
     this.mailController = new MailWindowController()
     this.trayController = new TrayController(this.mailController)
+    this.menuController = new MenuController()
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const { app } = require('electron')
+const { app, Menu } = require('electron')
 const MailWindowController = require('./controller/mail-window-controller')
 const TrayController = require('./controller/tray-controller')
 
@@ -49,6 +49,27 @@ class ElectronOutlook {
         this.mailController.show()
       }
     })
+    
+    const menuTemplate = [{
+      label: "Application",
+      submenu: [
+        { label: "About Application", selector: "orderFrontStandardAboutPanel:" },
+        { type: "separator" },
+        { label: "Quit", accelerator: "Command+Q", click: function() { app.quit(); }}
+      ]}, {
+      label: "Edit",
+      submenu: [
+        { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
+        { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
+        { type: "separator" },
+        { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
+        { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
+        { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
+        { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" }
+      ]}
+    ];
+
+    Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
   }
 
   createControllers() {


### PR DESCRIPTION
Previously app did not allow you to copy and paste and other standard keyboard shortcuts on Mac. It now does. 