### PR TITLE
enable windows authentication

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,9 @@ const { app } = require('electron')
 const MailWindowController = require('./controller/mail-window-controller')
 const TrayController = require('./controller/tray-controller')
 const MenuController = require('./controller/menu-controller')
+app.commandLine.appendSwitch("auth-server-whitelist", "*");
+app.commandLine.appendSwitch("enable-ntlm-v2", "true");
+
 
 class ElectronOutlook {
   constructor() {


### PR DESCRIPTION
Hello, 
In the electron app https://github.com/IsmaelMartinez/teams-for-linux, they added these 2 parameters to enable internal authentications through the webapp. In my company, when trying to connect to outlook, we are redirected to an internal authentication. As for now it was not possible to do so with freelook (a blank page is displayed). This PR should correct this!