### PR TITLE
Bump versions of dependencies to overcome build issues on macOS Catalina

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
     "postinstall": "electron-builder install-app-deps",
     "publish": "build -p always"
   },
-  "devDependencies": {
-    "electron": "^9.1.0",
-    "electron-builder": "^20.44.4"
+	"devDependencies": {
+    "electron": ">=9.1.0",
+    "electron-builder": ">=22.8.0"
   },
   "dependencies": {
-    "electron-settings": "^3.2.0",
-    "electron-spellchecker": "^2.2.1",
-    "fs-extra": "^5.0.0",
-    "is-online": "^8.2.0"
+    "electron-settings": ">=3.2.0",
+    "electron-spellchecker": ">=2.2.1",
+    "fs-extra": ">=5.0.0",
+    "is-online": ">=8.2.0"
   },
   "build": {
     "appId": "nz.co.enkru.${name}",


### PR DESCRIPTION
Due to https://github.com/electron-userland/electron-builder/issues/3990, electron-builder 20.44.4 won't build on macOS Catalina. Updating its min version and other deps' min versions fixes this.