### PR TITLE
feat: add refresh page function to UI

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -103,6 +103,11 @@ pub fn restart_app(app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub fn refresh_page(app: AppHandle) -> Result<(), String> {
+    windows::refresh_page(app)
+}
+
+#[tauri::command]
 pub fn css_inject(app: AppHandle, webview_label: String, css: String) -> Result<(), String> {
     windows::css_inject(app, webview_label, css)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run() {
             commands::reset_window_frame,
             commands::open_settings,
             commands::restart_app,
+            commands::refresh_page,
             commands::css_inject,
             commands::submit_login,
             commands::open_external_url,
@@ -70,6 +71,17 @@ pub fn run() {
             // Set up native menu
             let menu = menu::create_menu(&app_handle).expect("Failed to create menu");
             app.set_menu(menu).expect("Failed to set menu");
+
+            // Handle native menu events
+            let app_handle_menu = app.handle().clone();
+            app.on_menu_event(move |_app, event| {
+                match event.id().as_ref() {
+                    "refresh" => {
+                        let _ = windows::refresh_page(app_handle_menu.clone());
+                    }
+                    _ => {}
+                }
+            });
 
             // Start loading Outlook immediately. Network probing only controls the splash fallback.
             let app_handle2 = app.handle().clone();

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,5 +1,5 @@
 use tauri::{
-    menu::{Menu, MenuBuilder, PredefinedMenuItem, SubmenuBuilder},
+    menu::{Menu, MenuBuilder, MenuItem, PredefinedMenuItem, SubmenuBuilder},
     AppHandle,
 };
 
@@ -18,6 +18,12 @@ pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, Box<dyn std::err
         .item(&PredefinedMenuItem::select_all(app, None)?)
         .build()?;
 
+    // View menu with Refresh
+    let refresh_item = MenuItem::with_id(app, "refresh", "Refresh", true, Some("CmdOrCtrl+R"))?;
+    let view_menu = SubmenuBuilder::new(app, "View")
+        .item(&refresh_item)
+        .build()?;
+
     if is_macos {
         // macOS Application menu
         let app_menu = SubmenuBuilder::new(app, "Application")
@@ -29,6 +35,7 @@ pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, Box<dyn std::err
         let menu = MenuBuilder::new(app)
             .item(&app_menu)
             .item(&edit_menu)
+            .item(&view_menu)
             .build()?;
 
         Ok(menu)
@@ -36,6 +43,7 @@ pub fn create_menu(app: &AppHandle) -> Result<Menu<tauri::Wry>, Box<dyn std::err
         // Non-macOS: Edit menu ensures Ctrl+C/V/X work
         let menu = MenuBuilder::new(app)
             .item(&edit_menu)
+            .item(&view_menu)
             .build()?;
 
         Ok(menu)

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -64,6 +64,7 @@ pub fn create_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
 
     // Build context menu
     let open_item = MenuItem::with_id(app, "open", "Open", true, None::<&str>)?;
+    let refresh_item = MenuItem::with_id(app, "refresh", "Refresh", true, None::<&str>)?;
     let settings_item = MenuItem::with_id(app, "settings", "Settings", true, None::<&str>)?;
     let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
@@ -72,6 +73,7 @@ pub fn create_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         app,
         &[
             &open_item,
+            &refresh_item,
             &separator,
             &settings_item,
             &separator,
@@ -93,6 +95,9 @@ pub fn create_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                     let _ = window.show();
                     let _ = window.set_focus();
                 }
+            }
+            "refresh" => {
+                let _ = windows::refresh_page(app.clone());
             }
             "settings" => {
                 let _ = windows::open_settings(app.clone());

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -317,6 +317,14 @@ pub fn restart_app(app: AppHandle) -> Result<(), String> {
     app.restart();
 }
 
+/// Refresh (reload) the main webview page
+pub fn refresh_page(app: AppHandle) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window("main") {
+        window.eval("location.reload()").map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 /// Inject CSS into a webview
 pub fn css_inject(app: AppHandle, webview_label: String, css: String) -> Result<(), String> {
     if let Some(window) = app.get_webview_window(&webview_label) {


### PR DESCRIPTION
- Add refresh_page command that reloads the main webview via location.reload()
- Add View menu with Refresh item (Cmd+R / Ctrl+R shortcut)
- Add Refresh option to system tray context menu
- Register refresh_page in Tauri invoke handler