### PR TITLE
fix: enable HTML5 drag and drop in Outlook Web

### DIFF
--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -196,6 +196,7 @@ pub fn create_main_window(app: &AppHandle) -> Result<(), String> {
     .inner_size(width, height)
     .position(x, y)
     .visible(false)
+    .disable_drag_drop_handler()
     .on_navigation(move |url| {
         if is_microsoft_url(url) {
             true


### PR DESCRIPTION
## Summary
- Disable Tauri's native drag-drop handler on the main window to allow Outlook Web's HTML5 drag-and-drop API to work
- Fixes file attachment via drag-from-OS and internal email drag-to-move

## Problem
Tauri 2's native drag-drop handler intercepts OS-level drag events before they reach the webview. This prevents Outlook Web's HTML5 `dragstart`/`dragover`/`drop` events from firing, breaking two core features:
1. **File attachment**: Dragging files from Finder/Explorer onto the compose window
2. **Email drag-and-drop**: Moving emails between folders by dragging within the UI

## Fix
Added `.disable_drag_drop_handler()` to the main window's `WebviewWindowBuilder` in `windows.rs:199`. This lets the webview handle drag-drop events natively through its built-in HTML5 implementation.

## Test plan
- [ ] Drag a file from OS file manager onto Outlook's compose window → should attach
- [ ] Drag an email to a different folder in Outlook Web → should move
- [ ] Verify window title-bar dragging still works (CSS `-webkit-app-region: drag`)