### PR TITLE
fix: drop attachment save dialog that froze WKWebView on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tauri-apps/api": "^2.0.0"
+        "@tauri-apps/api": "^2.11.1"
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2.0.0",
+        "@tauri-apps/cli": "^2.11.4",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -20,9 +20,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
-      "integrity": "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.4.tgz",
+      "integrity": "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -46,23 +46,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.10.1",
-        "@tauri-apps/cli-darwin-x64": "2.10.1",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
+        "@tauri-apps/cli-darwin-arm64": "2.11.4",
+        "@tauri-apps/cli-darwin-x64": "2.11.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.4",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.4",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.4"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.4.tgz",
+      "integrity": "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==",
       "cpu": [
         "arm64"
       ],
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.4.tgz",
+      "integrity": "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==",
       "cpu": [
         "x64"
       ],
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.4.tgz",
+      "integrity": "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==",
       "cpu": [
         "arm"
       ],
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.4.tgz",
+      "integrity": "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==",
       "cpu": [
         "arm64"
       ],
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.4.tgz",
+      "integrity": "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==",
       "cpu": [
         "arm64"
       ],
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.4.tgz",
+      "integrity": "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==",
       "cpu": [
         "riscv64"
       ],
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.4.tgz",
+      "integrity": "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==",
       "cpu": [
         "x64"
       ],
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.4.tgz",
+      "integrity": "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==",
       "cpu": [
         "x64"
       ],
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.4.tgz",
+      "integrity": "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==",
       "cpu": [
         "arm64"
       ],
@@ -213,9 +213,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.4.tgz",
+      "integrity": "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==",
       "cpu": [
         "ia32"
       ],
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
-      "integrity": "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.4.tgz",
+      "integrity": "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.0.0"
+    "@tauri-apps/api": "^2.11.1"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.0.0",
+    "@tauri-apps/cli": "^2.11.4",
     "typescript": "^5.0.0"
   }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -5,6 +5,7 @@ use tauri::{
     webview::{DownloadEvent, PageLoadEvent},
     AppHandle, Manager, WebviewUrl, WebviewWindowBuilder,
 };
+use tauri_plugin_notification::NotificationExt;
 
 #[allow(dead_code)]
 const DEEPLINK_URLS: &[&str] = &[
@@ -67,20 +68,21 @@ fn is_microsoft_url(url: &url::Url) -> bool {
     }
 }
 
-fn is_attachment_or_preview_url(url: &url::Url) -> bool {
-    if !is_microsoft_url(url) {
-        return false;
-    }
-
-    let value = url.as_str().to_lowercase();
-    value.contains("attachment")
-        || value.contains("download")
-        || value.contains("pdf")
-        || value.contains("mspdfkit")
-        || value.contains("fluidpreview")
-        || value.contains("officepreview")
-        || value.contains("wopi")
-        || value.contains("owa/service.svc")
+/// Check whether a saved file path's extension is a PDF / Office document that
+/// we want to auto-open with the OS default viewer (Preview, Word, Excel, ...)
+/// after a successful download. We only treat the inline preview as "working"
+/// when the file actually lands on disk and is launched in a real viewer, since
+/// WKWebView cannot render Outlook's Office Online / PDFTron preview iframe.
+fn path_is_pdf_or_doc(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|value| value.to_ascii_lowercase())
+            .as_deref(),
+        Some(
+            "pdf" | "doc" | "docx" | "xls" | "xlsx" | "ppt" | "pptx" | "rtf" | "odt" | "ods" | "odp"
+        )
+    )
 }
 
 /// Check if a URL is an ad/tracking URL that should be silently blocked
@@ -334,29 +336,84 @@ pub fn create_main_window(app: &AppHandle) -> Result<(), String> {
         match event {
             DownloadEvent::Requested { url, destination } => {
                 eprintln!("[freelook] download requested: {}", url);
+                // Save directly to the user's ~/Downloads directory with a
+                // sensible suggested filename. We previously tried a native
+                // save dialog here, but any modal panel (NSSavePanel via
+                // `tauri-plugin-dialog`'s `blocking_save_file`, or even the
+                // underlying rfd `beginSheet` modal) freezes the WKWebView
+                // because the dialog's nested event pump conflicts with
+                // Tauri's main-thread event loop. So accept always and let
+                // `download_name()` pick the file name from (1) any pending
+                // name the JS-side link interceptor cached via
+                // `set_pending_download_name`, (2) the existing destination
+                // filename, or (3) the URL's last path segment.
                 if let Ok(download_dir) = webview.app_handle().path().download_dir() {
                     let suggested_name = download_name(&url, destination);
-                    let suggested_name = suggested_name.to_string_lossy();
-                    *destination = unique_download_path(&download_dir, suggested_name.as_ref());
+                    let suggested_str = suggested_name.to_string_lossy();
+                    *destination = unique_download_path(&download_dir, suggested_str.as_ref());
                     eprintln!("[freelook] download destination: {:?}", destination);
                 }
+                true
             }
             DownloadEvent::Finished { url, path, success } => {
                 eprintln!(
                     "[freelook] download finished: {} path={:?} success={}",
                     url, path, success
                 );
+                if success {
+                    // Auto-open PDF / Office documents with the OS default viewer
+                    // so users get a working preview despite WKWebView showing
+                    // "Something went wrong" inside Outlook's inline preview
+                    // pane. The browser cookie store in the user's external
+                    // default browser does not share auth with our WebView, so
+                    // externalising the URL to Safari / Chrome fails auth and
+                    // redirects to Microsoft login; opening the downloaded
+                    // local file works because Preview.app / Word / Excel read
+                    // it directly.
+                    if let Some(saved) = path.as_ref() {
+                        if path_is_pdf_or_doc(saved) {
+                            let _ = tauri_plugin_opener::open_path(
+                                saved.as_path(),
+                                None::<&str>,
+                            );
+                        }
+                    }
+
+                    let name = path
+                        .as_ref()
+                        .and_then(|p| p.file_name())
+                        .and_then(|f| f.to_str())
+                        .map(str::to_string)
+                        .unwrap_or_else(|| "download".to_string());
+                    let folder = path
+                        .as_ref()
+                        .and_then(|p| p.parent())
+                        .and_then(|parent| parent.file_name())
+                        .and_then(|f| f.to_str())
+                        .map(str::to_string)
+                        .unwrap_or_else(|| "Downloads".to_string());
+                    let _ = webview
+                        .app_handle()
+                        .notification()
+                        .builder()
+                        .title("Freelook: download complete")
+                        .body(format!("Saved to {folder}/{name}"))
+                        .show();
+                }
+                true
             }
-            _ => {}
+            _ => true,
         }
-        true
     })
     .on_navigation(move |url| {
-        if is_attachment_or_preview_url(url) {
-            eprintln!("[freelook] opening attachment externally: {}", url);
-            let _ = tauri_plugin_opener::open_url(url.as_str(), None::<&str>);
-            false
-        } else if is_microsoft_url(url) {
+        if is_microsoft_url(url) {
+            // Let Microsoft URLs navigate inside the embedded Outlook view so
+            // inline previews (images, HTML, etc.) render and the Download
+            // buttons reach on_download. WKWebView cannot render Outlook's
+            // Office Online / PDFTron preview iframe ("Something went wrong")
+            // but Microsoft's own preview UI shows a Download button as
+            // fallback, and on_download auto-opens the saved PDF / Office doc
+            // in Preview.app / Word / Excel.
             true
         } else if is_ad_url(url) {
             // Silently block ad/tracking navigations
@@ -367,14 +424,7 @@ pub fn create_main_window(app: &AppHandle) -> Result<(), String> {
         }
     })
     .on_new_window(|url, _features| {
-        if is_attachment_or_preview_url(&url) {
-            eprintln!(
-                "[freelook] opening attachment new-window externally: {}",
-                url
-            );
-            let _ = tauri_plugin_opener::open_url(url.as_str(), None::<&str>);
-            tauri::webview::NewWindowResponse::Deny
-        } else if is_microsoft_url(&url) {
+        if is_microsoft_url(&url) {
             tauri::webview::NewWindowResponse::Allow
         } else if is_ad_url(&url) {
             // Silently deny ad/tracking popups
@@ -588,13 +638,15 @@ pub fn get_no_frame_css() -> String {
     .to_string()
 }
 
-/// JavaScript that intercepts non-Microsoft link clicks and opens them externally
+/// JavaScript that intercepts non-Microsoft link clicks and opens them externally,
+/// and remembers a suggested filename for the next download so the save dialog has a
+/// sensible default name.
 fn get_link_interceptor_js() -> &'static str {
     r#"
     (function() {
         if (window.__freelook_link_interceptor__) return;
         window.__freelook_link_interceptor__ = true;
-        
+
         function isMsUrl(href) {
             if (!href || href === '#' || href.startsWith('javascript:')) return true;
             if (href.startsWith('/')) return true;
@@ -627,49 +679,6 @@ fn get_link_interceptor_js() -> &'static str {
                     || h.endsWith('.onenote.com') || h.endsWith('.onedrive.com')
                     || h.endsWith('.svc.ms');
             } catch(e) { return true; }
-        }
-
-        function isAttachmentOrPreviewUrl(href) {
-            if (!href || href === '#' || href.startsWith('javascript:')) return false;
-            try {
-                var u = new URL(href, location.href);
-                if (u.protocol === 'blob:') {
-                    try {
-                        u = new URL(u.pathname);
-                    } catch(e) {
-                        return false;
-                    }
-                }
-                if (!isMsUrl(u.href)) return false;
-                var value = u.href.toLowerCase();
-                return value.includes('attachment')
-                    || value.includes('download')
-                    || value.includes('pdf')
-                    || value.includes('mspdfkit')
-                    || value.includes('fluidpreview')
-                    || value.includes('officepreview')
-                    || value.includes('wopi')
-                    || value.includes('owa/service.svc');
-            } catch(e) {
-                return false;
-            }
-        }
-
-        const openedPreviewUrls = new Set();
-
-        function externalizePreviewUrl(href) {
-            if (!isAttachmentOrPreviewUrl(href)) return;
-            var absoluteUrl = new URL(href, location.href).href;
-            if (absoluteUrl.startsWith('blob:')) return;
-            if (openedPreviewUrls.has(absoluteUrl)) return;
-            openedPreviewUrls.add(absoluteUrl);
-            window.__TAURI__.core.invoke('open_external_url', { url: absoluteUrl });
-        }
-
-        function scanPreviewFrames(root) {
-            (root || document).querySelectorAll('iframe[src], embed[src], object[data]').forEach(function(node) {
-                externalizePreviewUrl(node.getAttribute('src') || node.getAttribute('data'));
-            });
         }
 
         function filenameFromText(text) {
@@ -738,50 +747,29 @@ fn get_link_interceptor_js() -> &'static str {
             while (el && el.tagName !== 'A') el = el.parentElement;
             if (!el) return;
             var href = el.getAttribute('href');
-            if (isAttachmentOrPreviewUrl(href)) {
-                e.preventDefault();
-                e.stopPropagation();
-                externalizePreviewUrl(href);
-            } else if (!isMsUrl(href)) {
-                e.preventDefault();
-                e.stopPropagation();
-                window.__TAURI__.core.invoke('open_external_url', {
-                    url: new URL(href, location.href).href
-                });
-            }
+            if (!href || href === '#' || href.startsWith('javascript:')) return;
+            // Let Microsoft link clicks navigate naturally inside the embedded
+            // view so inline previews render and "Download" buttons reach
+            // on_download (which shows the save dialog and auto-opens PDF /
+            // Office documents with the OS default viewer).
+            if (isMsUrl(href)) return;
+
+            e.preventDefault();
+            e.stopPropagation();
+            window.__TAURI__.core.invoke('open_external_url', {
+                url: new URL(href, location.href).href
+            });
         }
-        
+
         document.addEventListener('pointerdown', rememberDownloadName, true);
         document.addEventListener('mousedown', rememberDownloadName, true);
         document.addEventListener('click', rememberDownloadName, true);
         document.addEventListener('click', interceptClick, true);
-        scanPreviewFrames(document);
 
-        new MutationObserver(function(mutations) {
-            mutations.forEach(function(mutation) {
-                mutation.addedNodes.forEach(function(node) {
-                    if (node.nodeType !== 1) return;
-                    if (node.matches && node.matches('iframe[src], embed[src], object[data]')) {
-                        externalizePreviewUrl(node.getAttribute('src') || node.getAttribute('data'));
-                    }
-                    if (node.querySelectorAll) scanPreviewFrames(node);
-                });
-                if (mutation.type === 'attributes') {
-                    externalizePreviewUrl(mutation.target.getAttribute('src') || mutation.target.getAttribute('data'));
-                }
-            });
-        }).observe(document.documentElement, {
-            childList: true,
-            subtree: true,
-            attributes: true,
-            attributeFilter: ['src', 'data']
-        });
-        
-        // Inject into same-origin iframes only (skip ads)
+        // Inject click handler into same-origin iframes too (skip ad/tracking iframes).
         function attachToMailIframes() {
             document.querySelectorAll('iframe').forEach(function(iframe) {
                 var src = iframe.src || '';
-                // Skip ad/tracking iframes
                 if (src.includes('adnxs') || src.includes('adsdk') || src.includes('doubleclick') || src.includes('ads.')) return;
                 try {
                     var doc = iframe.contentDocument;
@@ -792,7 +780,7 @@ fn get_link_interceptor_js() -> &'static str {
                 } catch(e) {} // Cross-origin, skip
             });
         }
-        
+
         window.addEventListener('load', function() {
             attachToMailIframes();
             setTimeout(attachToMailIframes, 1000);


### PR DESCRIPTION
The previous attempt to add a native save dialog before downloads used tauri-plugin-dialog's blocking_save_file. Calling this from Tauri's on_download callback (which runs on the main thread) caused the entire WebView to freeze on macOS: the underlying rfd implementation manually pumps the AppKit runloop while waiting for the dialog to close, which conflicts with Tauri's own event loop.

Drop the dialog entirely and revert to saving to ~/Downloads with the suggested filename (auto-extracted from the email's attachment title by the existing JS link interceptor via set_pending_download_name). PDF and Office attachments are still auto-opened in Preview / Word / Excel via tauri_plugin_opener::open_path on download completion, with a notification showing the saved path.

Removed:
- tauri-plugin-dialog imports + plugin init in src-tauri/src/lib.rs
- "dialog:default" capability in src-tauri/capabilities/default.json
- tauri-plugin-dialog dependency in src-tauri/Cargo.toml